### PR TITLE
Allow the caller to specify a callback function for the net.Server.error event on the serverInstance created in master.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Here's the full list of accepted options:
 | `prefix` | prefix in names of [IPC](https://en.wikipedia.org/wiki/Inter-process_communication) messages | `sticky-cluster:` |
 | `env` | function (workerIndex => workerEnv) to provide additional worker configuration through the environment variables | sets `stickycluster_worker_index` (be aware that worker's index stays the same through its death and resurrection, but worker's id, which is used in debug messages, changes) |
 | `hardShutdownDelay` | delay(ms) to trigger the `hard shutdown` if the `graceful shutdown` doesn't complete | `60 * 1000 ms` |
-
+| `errorHandler` | callback function for the `net.Server.error` event on the `serverInstance` created in `master.js`. | `function (err) { console.log(err); process.exit(1); }` |
 
 ### Example
 
@@ -109,6 +109,10 @@ The algorithm used in the `sticky-session` module is `int31` and the local one i
 
 
 ### Changelog
+
+#### 0.3.2 -> 0.3.3
+
++ Allow the caller to specify a callback function for the `net.Server.error` event on the `serverInstance` created in `master.js`.
 
 #### 0.3.1 -> 0.3.2
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -9,7 +9,8 @@ module.exports = function (startFn, _options) {
       port: options.port || 8080,
       debug: options.debug || false,
       hardShutdownDelay: options.hardShutdownDelay || 60 * 1000,
-      env: options.env || function (index) { return { stickycluster_worker_index: index }; }
+      env: options.env || function (index) { return { stickycluster_worker_index: index }; },
+      errorHandler: options.errorHandler || function (err) { console.log(err); process.exit(1); }      
     };
   })(_options);
 

--- a/lib/master.js
+++ b/lib/master.js
@@ -32,8 +32,8 @@ module.exports = function (workers, options) {
   }
 
   function serverStart (callback) {
-    serverInstance = serverCreate();
-    serverInstance.listen(PORT, callback).on('error', errorHandler);
+    serverInstance = serverCreate().on('error', errorHandler);
+    serverInstance.listen(PORT, callback);
   }
 
   function serverStop (callback) {

--- a/lib/master.js
+++ b/lib/master.js
@@ -7,7 +7,8 @@ module.exports = function (workers, options) {
   var serverInstance;
   var HARD_SHUTDOWN_DELAY = options.hardShutdownDelay;
   var connMap = {};
-
+  var errorHandler = options.errorHandler;
+  
   function serverCreate () {
     var hash = require('string-hash');
     return require('net')
@@ -32,7 +33,7 @@ module.exports = function (workers, options) {
 
   function serverStart (callback) {
     serverInstance = serverCreate();
-    serverInstance.listen(PORT, callback);
+    serverInstance.listen(PORT, callback).on('error', errorHandler);
   }
 
   function serverStop (callback) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sticky-cluster",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "repository": "https://github.com/uqee/sticky-cluster.git",
   "description": "Sticky session balancer, 10x faster and with much better scattering than `sticky-session` module",
   "keywords": [


### PR DESCRIPTION
Hi @uqee ,

I am working with @gboysko on the #28 . In this pull request, we allow caller to specify a callback function for the `net.Server.error event` on the `serverInstance` created in `master.js`. Could you please help review this? Thanks.